### PR TITLE
Upgrade jinja2 to 3.1.4 .

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pylint_report"
 description = "Generates an html report summarizing the results of pylint."
 readme = "README.rst"
 requires-python = ">=3.8"
-dependencies = ["pylint", "Jinja2==3.1.2", "pandas==1.5.2", "argcomplete"]
+dependencies = ["pylint", "Jinja2==3.1.4", "pandas==1.5.2", "argcomplete"]
 dynamic = ["version"]
 
 [[project.authors]]


### PR DESCRIPTION
To address  CVE-2024-34064 https://github.com/advisories/GHSA-h75v-3vvj-5mfj

I understand there's a PR from dependabot to upgrade jinja2 to 3.1.3 , but there's another vulnerability CVE-2024-34064 that's fixed in 3.1.4 .

Could you please publish a new version with this update?
Thanks in advance for your help.